### PR TITLE
Fix simple_delta crash when latest_pk_version was never bootstrapped

### DIFF
--- a/odbc2deltalake/db_to_delta.py
+++ b/odbc2deltalake/db_to_delta.py
@@ -541,6 +541,16 @@ def do_delta_load(
             )
             return do_full_load(infos=infos, mode="append")
 
+    if simple and not reader.local_delta_table_exists(
+        destination / f"delta_load/{DBDeltaPathConfigs.LATEST_PK_VERSION}"
+    ):
+        # simple_delta has no restore-pk fallback (unlike the non-simple path
+        # above): if latest_pk_version was never written (eg the destination
+        # was bootstrapped by a delta_col-less full load), fall back to a
+        # full load instead of crashing later on the missing primary_keys_ts.
+        logger.warning("latest_pk_version missing for simple_delta, do a full load")
+        return do_full_load(infos=infos, mode="append")
+
     old_pk_version = (
         reader.get_local_delta_ops(
             destination / "delta_load" / DBDeltaPathConfigs.LATEST_PK_VERSION

--- a/tests/test_20_simple_delta_bootstrap.py
+++ b/tests/test_20_simple_delta_bootstrap.py
@@ -1,0 +1,80 @@
+"""Reproduces https://github.com/bmsuisse/odbc2deltalake/issues/67
+
+If a delta destination is bootstrapped by a full load that has no delta_col
+(e.g. an "init" style load where the delta column couldn't be detected /
+wasn't configured yet), `do_full_load` returns early without ever writing
+`delta_load/latest_pk_version` (see `db_to_delta.py`, `do_full_load`: "if
+infos.delta_col is None: return FullLoadResult()").
+
+A later `simple_delta`/`simple_delta_check` load against that same
+destination (now with a proper delta_col configured) skips the bootstrap
+guard that the non-simple delta path has (`do_delta_load` sets
+`last_pk_path = None` whenever `simple=True`, so the
+"Primary keys missing, try to restore" / "do a full load" fallback never
+runs). Execution falls through to `write_latest_pk(merge_delta=False)` ->
+`_get_latest_pk_query(merge_delta=False)`, which unconditionally tries to
+register `delta_load/primary_keys_ts` as a view - a path that was never
+created, since `primary_keys_ts` is only written by the non-simple delta
+path's `_retrieve_primary_key_data`.
+"""
+
+import dataclasses
+from typing import TYPE_CHECKING
+import pytest
+from .utils import config_names, get_test_run_configs
+
+if TYPE_CHECKING:
+    from tests.conftest import DB_Connection
+    from pyspark.sql import SparkSession
+
+
+@pytest.mark.order(21)
+@pytest.mark.parametrize("conf_name", config_names)
+def test_simple_delta_after_delta_col_less_init(
+    connection: "DB_Connection", spark_session: "SparkSession", conf_name: str
+):
+    from odbc2deltalake import WriteConfig, make_writer
+    from odbc2deltalake.db_to_delta import do_full_load
+
+    # use a destination path distinct from other tests targeting dbo.company3,
+    # so we control the bootstrap state (no leftover latest_pk_version)
+    reader, dest = get_test_run_configs(
+        connection, spark_session, "dbo/company3_bootstrap"
+    )[conf_name]
+
+    # Step 1: "init" load with no delta_col - mirrors bootstrapping a table
+    # before a delta column is known/configured. do_full_load with
+    # delta_col=None does not write delta_load/latest_pk_version.
+    init_config = WriteConfig(dialect=reader.source_dialect)
+    init_infos = make_writer(reader, ("dbo", "company3"), dest, init_config)
+    init_infos = dataclasses.replace(init_infos, delta_col=None)
+    do_full_load(init_infos, mode="overwrite")
+
+    assert not (dest / "delta_load" / "latest_pk_version").exists()
+    assert (dest / "delta").exists()
+
+    # Change the source so there actually is something to sync - otherwise
+    # do_delta_load short-circuits on "No updates, done" before ever
+    # reaching write_latest_pk, and the bug wouldn't be exercised.
+    with connection.new_connection(conf_name) as nc:
+        with nc.cursor() as cursor:
+            cursor.execute(
+                "insert into dbo.company3(id, name) values "
+                "('c301', 'company3_bootstrap_test') "
+                "on conflict do nothing"
+                if reader.source_dialect == "postgres"
+                else "if not exists (select 1 from dbo.company3 where id = 'c301') "
+                "insert into dbo.company3(id, name) values ('c301', 'company3_bootstrap_test')"
+            )
+
+    # Step 2: a normal simple_delta load against the same destination, now
+    # with a properly detected delta_col. Since destination/delta already
+    # exists, exec_write_db_to_delta routes straight into do_delta_load
+    # instead of do_full_load, and the simple path has no bootstrap guard.
+    simple_config = WriteConfig(
+        load_mode="simple_delta", dialect=reader.source_dialect
+    )
+    simple_infos = make_writer(reader, ("dbo", "company3"), dest, simple_config)
+    assert simple_infos.delta_col is not None, "test setup needs a real delta col"
+
+    simple_infos.execute()  # must not raise


### PR DESCRIPTION
Fixes #67.

`do_full_load` only writes `delta_load/latest_pk_version` when `infos.delta_col` is set. If a destination is first bootstrapped by a full load with no `delta_col` (e.g. an init-style load before the delta column is configured), `latest_pk_version` is never created. `do_delta_load`'s non-simple path already guards against this (falls back to `restore_last_pk`, then a full load), but the `simple_delta`/`simple_delta_check` path sets `last_pk_path=None` and skips that guard entirely, falling through to `write_latest_pk(merge_delta=False)` -> `_get_latest_pk_query`, which unconditionally tries to register the (also never created) `delta_load/primary_keys_ts` view and crashes (`TableNotFoundError` locally / `PATH_NOT_FOUND` on Databricks) - matching the crash reported in #67.

Fix: an explicit bootstrap guard for the simple path - if `latest_pk_version` doesn't exist yet, do a full load instead (which creates it), same as the guard the non-simple path already has, and the same approach proposed in the issue.

Test: `tests/test_20_simple_delta_bootstrap.py` reproduces the crash end-to-end against a real postgres source (full load without `delta_col`, then a source change, then a `simple_delta` load). Fails on `main` with `TableNotFoundError: no log files`. Passes with this fix.

This PR (and its explanation of #67's root cause) were produced by Claude (Anthropic), working on behalf of @dominikpeter - please review accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)