### PR TITLE
Fix ADBCReader leaking uncommitted transactions, causing indefinite lock hangs

### DIFF
--- a/odbc2deltalake/reader/adbc_reader.py
+++ b/odbc2deltalake/reader/adbc_reader.py
@@ -253,9 +253,12 @@ class ADBCReader(DataSourceReader):
         from ..metadata import InformationSchemaColInfo
 
         limit_sql = sql.limit(0).sql(self.source_dialect)
-        with self.connection.cursor() as cursor:
-            cursor.execute(limit_sql)
-            sc = cursor.fetch_arrow_table().schema
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(limit_sql)
+                sc = cursor.fetch_arrow_table().schema
+        finally:
+            self.connection.commit()
         return [
             InformationSchemaColInfo(
                 column_name=n,
@@ -270,12 +273,15 @@ class ADBCReader(DataSourceReader):
         if isinstance(sql, ex.Query):
             sql = sql.sql(self.source_dialect)
         result = list()
-        with self.connection.cursor() as cursor:
-            cursor.execute(sql)
-            assert cursor.description is not None
-            col_names = [desc[0] for desc in cursor.description]
-            for row in cursor.fetchall():
-                result.append(dict(zip(col_names, row)))
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(sql)
+                assert cursor.description is not None
+                col_names = [desc[0] for desc in cursor.description]
+                for row in cursor.fetchall():
+                    result.append(dict(zip(col_names, row)))
+        finally:
+            self.connection.commit()
         return result
 
     def source_write_sql_to_delta(
@@ -289,38 +295,41 @@ class ADBCReader(DataSourceReader):
         from deltalake import write_deltalake
         from deltalake.exceptions import DeltaError
 
-        with self.connection.cursor() as cursor:
-            cursor.execute(sql)
-            reader = cursor.fetch_record_batch()
+        try:
+            with self.connection.cursor() as cursor:
+                cursor.execute(sql)
+                reader = cursor.fetch_record_batch()
 
-            dp, do = delta_path.as_path_options(flavor="object_store")
-            cast_schema, schema_mode = self._handle_schema_drift(
-                delta_path, allow_schema_drift, mode, reader.schema
-            )
-
-            if cast_schema:
-                import pyarrow as pa
-
-                reader = pa.RecordBatchReader.from_batches(
-                    cast_schema, (b.cast(cast_schema) for b in reader)
+                dp, do = delta_path.as_path_options(flavor="object_store")
+                cast_schema, schema_mode = self._handle_schema_drift(
+                    delta_path, allow_schema_drift, mode, reader.schema
                 )
-            try:
-                write_deltalake(
-                    dp,
-                    reader,
-                    schema=_all_nullable(reader.schema),
-                    mode=mode,
-                    writer_properties=self.writer_properties,
-                    schema_mode=schema_mode,
-                    engine="rust",
-                    storage_options=do,
-                )
-            except DeltaError as e:
-                if "No data source supplied to write command" in str(e):
-                    if mode == "overwrite":
-                        self._write_empty_delta_table(reader.schema, dp, do)
-                else:
-                    raise e
+
+                if cast_schema:
+                    import pyarrow as pa
+
+                    reader = pa.RecordBatchReader.from_batches(
+                        cast_schema, (b.cast(cast_schema) for b in reader)
+                    )
+                try:
+                    write_deltalake(
+                        dp,
+                        reader,
+                        schema=_all_nullable(reader.schema),
+                        mode=mode,
+                        writer_properties=self.writer_properties,
+                        schema_mode=schema_mode,
+                        engine="rust",
+                        storage_options=do,
+                    )
+                except DeltaError as e:
+                    if "No data source supplied to write command" in str(e):
+                        if mode == "overwrite":
+                            self._write_empty_delta_table(reader.schema, dp, do)
+                    else:
+                        raise e
+        finally:
+            self.connection.commit()
 
     def _write_empty_delta_table(
         self,

--- a/tests/test_21_adbc_connection_leak.py
+++ b/tests/test_21_adbc_connection_leak.py
@@ -1,0 +1,52 @@
+"""ADBCReader (the Postgres/ADBC source reader) never called .commit() on its
+underlying connection anywhere - not in source_sql_to_py,
+source_schema_limit_one, or source_write_sql_to_delta. Since ADBC/postgres
+connections are not autocommit by default, every read left an open,
+uncommitted transaction holding locks on whatever table it touched, for the
+entire remaining lifetime of the connection.
+
+This is not a theoretical concern: it deadlocked the real test suite. Any
+later DDL against a table the reader had ever read from (eg a test doing
+`ALTER TABLE ... RENAME` to simulate a schema drift/restore scenario, or a
+real production schema migration) blocks forever on that stale lock.
+"""
+
+from typing import TYPE_CHECKING
+import pytest
+
+if TYPE_CHECKING:
+    from tests.conftest import DB_Connection
+
+
+@pytest.mark.order(22)
+def test_adbc_reader_does_not_leak_locks_across_calls(connection: "DB_Connection"):
+    if connection.source_server != "postgres":
+        pytest.skip("this bug is specific to the ADBC/postgres reader")
+
+    import adbc_driver_postgresql.dbapi as adbc_pg
+    from odbc2deltalake.reader.adbc_reader import ADBCReader
+
+    connstr = connection.conn_str["local"]
+    reader_conn = adbc_pg.connect(connstr)
+    reader = ADBCReader(reader_conn, local_db=":memory:", source_dialect="postgres")
+
+    # any read through the reader (schema query, row fetch) must not leave
+    # a lock-holding transaction open on the table it touched
+    reader.source_sql_to_py("select id, name from dbo.company3 limit 1")
+
+    check_conn = adbc_pg.connect(connstr, autocommit=True)
+    try:
+        with check_conn.cursor() as c:
+            c.execute("set lock_timeout = '3s'")
+            try:
+                c.execute("alter table dbo.company3 add column zzz_leak_test int")
+                c.execute("alter table dbo.company3 drop column zzz_leak_test")
+            except Exception as e:
+                pytest.fail(
+                    "ALTER TABLE on a table the ADBCReader had read from was "
+                    f"blocked - the reader is leaking a lock-holding, "
+                    f"uncommitted transaction: {e}"
+                )
+    finally:
+        check_conn.close()
+        reader_conn.close()


### PR DESCRIPTION
Fixes #70.

`ADBCReader.source_sql_to_py`, `source_schema_limit_one`, and `source_write_sql_to_delta` (`odbc2deltalake/reader/adbc_reader.py`) never called `.commit()` on the underlying ADBC postgres connection. Since ADBC/postgres connections default to `autocommit=off`, every read left an open, uncommitted transaction holding locks on whatever table it touched, for the remaining lifetime of the connection object.

Because a single `ADBCReader` connection is reused across every read/write call for a table's whole sync, this means: read a table once, and any later DDL against that same table (a schema migration, or - as in this repo's own tests - a rename used to simulate a restore-from-backup scenario) blocks forever waiting on that stale lock.

This is not theoretical - it deadlocked this repo's own test suite. Running locally against postgres via podman, `tests/test_04_strange_delta.py`'s `ALTER TABLE dbo.user3 RENAME TO user3_;` and `tests/test_11_schema_drift.py`'s `ALTER TABLE dbo.user7 add some_date ...` both hung indefinitely. Confirmed via `pg_stat_activity`: the reader's connection sits `idle in transaction`, holding an `ACCESS SHARE` lock, e.g.:

```
pid | state              | query
277 | idle in transaction | COPY (SELECT * FROM dbo.user5 WHERE ... LIMIT 0) TO STDOUT (FORMAT binary)
290 | active (blocked)   | ALTER TABLE dbo.user7 add some_date date not null default('2000-01-01');
```

A minimal, isolated reproduction (no test suite needed):

```python
reader = ADBCReader(adbc_pg.connect(connstr), source_dialect="postgres")
reader.source_sql_to_py("select id, name from dbo.company3 limit 1")

check_conn = adbc_pg.connect(connstr, autocommit=True)
with check_conn.cursor() as c:
    c.execute("set lock_timeout = '3s'")
    c.execute("alter table dbo.company3 add column zzz int")  # blocks, then:
    # ERROR: canceling statement due to lock timeout (SQLSTATE 55P03)
```

In a real deployment, any orchestration that reads more than one table with a long-lived `ADBCReader`/connection (the normal pattern per the README's usage example) risks holding locks against the *source* production database indefinitely.

Fix: commit the connection after each cursor-using operation, in a `try/finally` so a raised exception doesn't skip it either.

Test: `tests/test_21_adbc_connection_leak.py` runs one read through `ADBCReader`, then attempts an `ALTER TABLE` from a separate connection with a short `lock_timeout`, asserting it is not blocked. Confirmed this test fails against the pre-fix code (`canceling statement due to lock timeout`) and passes after the fix. With the fix, the two previously-hanging tests both now complete against postgres.

This PR (and issue #70) were produced by Claude (Anthropic), working on behalf of @dominikpeter - please review accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)