### PR TITLE
Fix postgres NUMERIC/DECIMAL columns silently becoming string (or crashing schema probes) via ADBC

### DIFF
--- a/odbc2deltalake/read_utils/delta_rs.py
+++ b/odbc2deltalake/read_utils/delta_rs.py
@@ -20,8 +20,22 @@ def _all_nullable(schema: "pa.Schema") -> "pa.Schema":
 
 
 def _get_type(tp: "pa.DataType"):
+    import pyarrow as pa
     import pyarrow.types as pat
 
+    if isinstance(tp, pa.OpaqueType):
+        # Some ADBC drivers (observed with adbc-driver-postgresql==1.7.0) return
+        # columns they can't losslessly map to a native Arrow type as an
+        # `arrow.opaque` extension wrapping the driver's storage representation,
+        # e.g. Postgres NUMERIC/DECIMAL columns (unbounded precision) come back as
+        # extension<arrow.opaque[storage_type=string, type_name=numeric,
+        # vendor_name=PostgreSQL]> for a plain `SELECT numeric_col FROM ...` - not
+        # specific to any particular query shape (WHERE/LIMIT/casts all reproduce
+        # it). Map known numeric/decimal opaque types to DECIMAL, and otherwise
+        # fall back to resolving the underlying storage type rather than raising.
+        if tp.vendor_name == "PostgreSQL" and tp.type_name in ("numeric", "decimal"):
+            return ex.DataType.Type.DECIMAL
+        return _get_type(tp.storage_type)
     if pat.is_string(tp):
         return ex.DataType.Type.NVARCHAR
     if pat.is_boolean(tp):

--- a/odbc2deltalake/reader/adbc_reader.py
+++ b/odbc2deltalake/reader/adbc_reader.py
@@ -19,6 +19,58 @@ if TYPE_CHECKING:
     from adbc_driver_manager.dbapi import Connection
 
 
+def _fix_pg_opaque_numeric(reader: "pa.RecordBatchReader") -> "pa.RecordBatchReader":
+    """adbc-driver-postgresql has no fixed-width Arrow equivalent for Postgres'
+    arbitrary-precision NUMERIC/DECIMAL type, so it represents those columns
+    as an opaque extension type backed by a plain string (eg "14.000"). Left
+    untouched, that string-backed type is what ends up in the written
+    Delta/Parquet schema - silently turning every postgres numeric/decimal
+    source column into a plain string column, regardless of what the source
+    column is actually declared as (and regardless of any later schema-drift
+    handling, which never sees anything but "string" for these columns).
+
+    Detect those opaque numeric columns and cast them back to a real
+    pyarrow decimal before they reach write_deltalake, so the written Delta
+    schema reflects DECIMAL rather than NVARCHAR/string. A generous fixed
+    (38, 18) target is used since the exact source precision/scale isn't
+    recoverable from the opaque type's metadata.
+    """
+    import pyarrow as pa
+    import pyarrow.compute as pc
+
+    schema = reader.schema
+    numeric_idx = [
+        i
+        for i, field in enumerate(schema)
+        if isinstance(field.type, pa.OpaqueType)
+        and field.type.vendor_name == "PostgreSQL"
+        and field.type.type_name in ("numeric", "decimal")
+    ]
+    if not numeric_idx:
+        return reader
+
+    target_type = pa.decimal128(38, 18)
+    new_schema = pa.schema(
+        [
+            f.with_type(target_type) if i in numeric_idx else f
+            for i, f in enumerate(schema)
+        ]
+    )
+
+    def _fix_batch(b: "pa.RecordBatch") -> "pa.RecordBatch":
+        cols = []
+        for i, col in enumerate(b.columns):
+            if i in numeric_idx:
+                storage = col.storage if isinstance(col, pa.ExtensionArray) else col
+                col = pc.cast(storage, target_type)
+            cols.append(col)
+        return pa.RecordBatch.from_arrays(cols, schema=new_schema)
+
+    return pa.RecordBatchReader.from_batches(
+        new_schema, (_fix_batch(b) for b in reader)
+    )
+
+
 class ADBCReader(DataSourceReader):
     def __init__(
         self,
@@ -292,6 +344,7 @@ class ADBCReader(DataSourceReader):
         with self.connection.cursor() as cursor:
             cursor.execute(sql)
             reader = cursor.fetch_record_batch()
+            reader = _fix_pg_opaque_numeric(reader)
 
             dp, do = delta_path.as_path_options(flavor="object_store")
             cast_schema, schema_mode = self._handle_schema_drift(


### PR DESCRIPTION
Fixes #74.

`adbc-driver-postgresql==1.7.0` has no fixed-width Arrow type for Postgres' arbitrary-precision `NUMERIC`/`DECIMAL`. Both `cursor.fetch_arrow_table()` and `cursor.fetch_record_batch()` return those columns as an `arrow.opaque` extension type (`storage_type=string, type_name=numeric, vendor_name=PostgreSQL`) - backed by a plain string, e.g. `"14.000"` - regardless of query shape or declared column precision/scale.

This surfaced as two distinct problems, both only reachable once #70 (the connection-leak deadlock, fixed separately) was fixed - the tests exercising these paths had never been able to run to completion against postgres before:

1. **Schema probe crash** (`tests/test_09_query.py`): `ADBCReader.source_schema_limit_one` -> `_get_type` (`odbc2deltalake/read_utils/delta_rs.py`) had no case for `pa.OpaqueType` and raised `ValueError: Type extension<arrow.opaque[...]> not supported`, hard-crashing `make_writer` for any query-based source that selects a numeric/decimal column.
2. **Silent data corruption on write** (`tests/test_11_schema_drift.py`): `ADBCReader.source_write_sql_to_delta` passed the fetched schema straight into `write_deltalake` without handling the opaque type, so **every** postgres numeric/decimal column was silently written to the Delta table as a `string` column - independent of any schema drift scenario, present since the very first write of any table with a numeric/decimal column.

Confirmed both isolated with a standalone `adbc_driver_postgresql.dbapi` script inspecting `field.type` directly - `pyarrow.lib.OpaqueType`, `storage_type=string`, `vendor_name=PostgreSQL`, `type_name=numeric`, reproducible for any query shape, `LIMIT 0`/`LIMIT 1`/no limit, with/without `WHERE`, bare `numeric` or `numeric(p,s)`.

## Fix

Two changes addressing both code paths at their root:

- `_get_type` in `odbc2deltalake/read_utils/delta_rs.py` now recognizes Postgres numeric/decimal `pa.OpaqueType` fields (mapping to `ex.DataType.Type.DECIMAL`) and falls back to the type's own `storage_type` for any other unrecognized opaque type, instead of raising.
- `odbc2deltalake/reader/adbc_reader.py` adds `_fix_pg_opaque_numeric()`, which detects these opaque numeric fields on the fetched `RecordBatchReader` in `source_write_sql_to_delta` and casts them to `pa.decimal128(38, 18)` before the batch reaches `write_deltalake`.

## Test

`tests/test_09_query.py` fails before this fix (`ValueError: Type extension<arrow.opaque...> not supported`) and passes after. Verified alongside `tests/test_01_first_full.py`/`test_02_full_load.py` for no regression in normal (non-opaque) type resolution.

This PR (and issue #74) were produced by Claude (Anthropic), working on behalf of @dominikpeter - please review accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)