### PR TITLE
Fix Databricks dialect never being detected in SparkReader

### DIFF
--- a/odbc2deltalake/reader/spark_reader.py
+++ b/odbc2deltalake/reader/spark_reader.py
@@ -1,3 +1,4 @@
+import os
 from .reader import DataSourceReader, DeltaOps
 from ..destination import Destination
 from sqlglot.expressions import Query, DataType
@@ -111,10 +112,18 @@ class SparkReader(DataSourceReader):
         self.transformation_hook: Callable[["DataFrame", str], "DataFrame"] = (
             transformation_hook or (lambda d, _: d)
         )
+        # spark.conf.get(key) with no default raises if the key isn't set
+        # (rather than returning None), so calling it bare here always threw
+        # and was silently swallowed by the broad except below - Databricks
+        # was therefore never actually detected. DATABRICKS_RUNTIME_VERSION
+        # is set in every Databricks cluster's environment and is the
+        # standard way to detect one; kept the spark.home check (now with an
+        # explicit default so it can't raise) as a secondary heuristic.
         try:
             self._dialect = (
                 "databricks"
-                if "/databricks" in (spark.conf.get("spark.home") or "")
+                if os.environ.get("DATABRICKS_RUNTIME_VERSION") is not None
+                or "/databricks" in (spark.conf.get("spark.home", "") or "")
                 else "spark"
             )
         except Exception:

--- a/tests/test_22_spark_databricks_dialect.py
+++ b/tests/test_22_spark_databricks_dialect.py
@@ -1,0 +1,50 @@
+"""SparkReader.__init__ tried to detect a Databricks runtime via
+`spark.conf.get("spark.home")` - but pyspark's RuntimeConfig.get(key) with no
+default raises (rather than returning None) when the key is unset, per
+pyspark's own source (pyspark/sql/conf.py: `if default is _NoValue: return
+self._jconf.get(key)`, and Spark's underlying SQLConf.get(key) throws
+NoSuchElementException for an absent key). Since "spark.home" is essentially
+never actually set as a runtime SQL conf, this call always raised, was
+silently swallowed by the broad `except Exception`, and `self._dialect`
+therefore fell back to "spark" unconditionally - even when genuinely running
+on Databricks. Databricks-specific SQL generation was consequently dead code.
+"""
+from unittest.mock import MagicMock
+
+
+def _spark_conf_get(*args):
+    # mirrors pyspark.sql.conf.RuntimeConfig.get: get(key) with no default
+    # raises for an unset key (real Spark: NoSuchElementException),
+    # get(key, default) returns the default instead of raising
+    if len(args) == 1:
+        raise KeyError(f"{args[0]} not set (simulating pyspark's NoSuchElementException)")
+    return args[1]
+
+
+def test_databricks_dialect_detected_via_env_var(monkeypatch):
+    from odbc2deltalake.reader.spark_reader import SparkReader
+
+    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "14.3")
+
+    fake_spark = MagicMock()
+    fake_spark.conf.get.side_effect = _spark_conf_get
+
+    reader = SparkReader(fake_spark, spark_format="sqlserver")
+
+    assert reader._dialect == "databricks", (
+        "Databricks runtime should be detected via DATABRICKS_RUNTIME_VERSION "
+        "even when spark.conf.get('spark.home') raises for an unset key"
+    )
+
+
+def test_plain_spark_dialect_when_not_on_databricks(monkeypatch):
+    from odbc2deltalake.reader.spark_reader import SparkReader
+
+    monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION", raising=False)
+
+    fake_spark = MagicMock()
+    fake_spark.conf.get.side_effect = _spark_conf_get
+
+    reader = SparkReader(fake_spark, spark_format="sqlserver")
+
+    assert reader._dialect == "spark"


### PR DESCRIPTION
Fixes #75.

`SparkReader.__init__` (`odbc2deltalake/reader/spark_reader.py`) tried to detect a Databricks runtime via `spark.conf.get("spark.home")`. pyspark's `RuntimeConfig.get(key)` with no default raises (rather than returning `None`) when the key is unset - confirmed from pyspark's own source (`pyspark/sql/conf.py`: `if default is _NoValue: return self._jconf.get(key)`, which calls the underlying Java `SQLConf.get(key)`, documented to throw `NoSuchElementException` for an absent key).

`"spark.home"` is essentially never actually set as a runtime SQL conf (on Databricks or elsewhere), so this call always raised, was silently swallowed by the surrounding `except Exception: self._dialect = "spark"`, and Databricks was therefore never detected - even when genuinely running on one. `self._dialect` drives all local SQL generation (`local_register_view`, `local_execute_sql_to_delta`, `local_upsert_into`), so Databricks-specific sqlglot dialect handling was dead code.

Fix: primarily detect Databricks via the `DATABRICKS_RUNTIME_VERSION` environment variable, which is set in every Databricks cluster's environment and is the standard way to detect one. Kept the `spark.home` substring check as a secondary heuristic, now with an explicit default so it can no longer raise.

Test: `tests/test_22_spark_databricks_dialect.py` uses a `MagicMock` Spark session whose `conf.get` mirrors real pyspark semantics (raises for `get(key)`, returns the default for `get(key, default)`) - a real `SparkSession` isn't available in this environment (pyspark 3.5 needs Java <=17). Confirmed the test fails against the pre-fix code and passes after.

This PR (and issue #75) were produced by Claude (Anthropic), working on behalf of @dominikpeter - please review accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)