### PR TITLE
Fix Azure credential cache ignoring kwargs, reusing the wrong identity

### DIFF
--- a/odbc2deltalake/destination/azure_utils.py
+++ b/odbc2deltalake/destination/azure_utils.py
@@ -24,17 +24,23 @@ default_azure_args = [
 ]
 
 
-_token_state = dict()
+_token_state: dict = dict()
 
 
 def _get_default_token(**kwargs) -> str:
     global _token_state
     from azure.identity import DefaultAzureCredential
 
-    cred: Union[DefaultAzureCredential, None] = _token_state.get("cred", None)
+    # cache key must include the kwargs: different destinations can use
+    # different identities (eg different managed_identity_client_id), and
+    # a single process-wide cache keyed only on "the first credential ever
+    # built" would silently reuse the wrong identity for every destination
+    # after the first.
+    cache_key = tuple(sorted(kwargs.items()))
+    cred: Union[DefaultAzureCredential, None] = _token_state.get(cache_key, None)
     if not cred:
         cred = DefaultAzureCredential(**kwargs)
-        _token_state["cred"] = cred
+        _token_state[cache_key] = cred
     return cred.get_token("https://storage.azure.com/.default").token
 
 

--- a/tests/test_23_azure_token_cache.py
+++ b/tests/test_23_azure_token_cache.py
@@ -1,0 +1,40 @@
+"""_get_default_token cached a single DefaultAzureCredential in a
+process-wide global keyed only on "the first credential ever built",
+ignoring the actual kwargs on every subsequent call. A pipeline reading
+from one storage account (managed_identity_client_id=A) and writing to
+another (managed_identity_client_id=B) would silently authenticate the
+second destination with the first destination's identity.
+"""
+from unittest.mock import MagicMock, patch
+
+import odbc2deltalake.destination.azure_utils as azure_utils
+
+
+def test_different_kwargs_get_different_cached_credentials():
+    azure_utils._token_state.clear()
+
+    created_with: list[dict] = []
+
+    class FakeCredential:
+        def __init__(self, **kwargs):
+            created_with.append(kwargs)
+            self.kwargs = kwargs
+
+        def get_token(self, *_a, **_kw):
+            return MagicMock(token=f"token-for-{self.kwargs}")
+
+    with patch("azure.identity.DefaultAzureCredential", FakeCredential):
+        token_a = azure_utils._get_default_token(managed_identity_client_id="A")
+        token_b = azure_utils._get_default_token(managed_identity_client_id="B")
+        # same kwargs again -> should reuse the cached credential, not build a 3rd
+        token_a_again = azure_utils._get_default_token(managed_identity_client_id="A")
+
+    assert token_a != token_b, (
+        "different managed_identity_client_id kwargs must not silently reuse "
+        "the first credential's token"
+    )
+    assert token_a == token_a_again
+    assert len(created_with) == 2, (
+        f"expected exactly 2 DefaultAzureCredential instances (one per distinct "
+        f"kwargs), got {len(created_with)}: {created_with}"
+    )


### PR DESCRIPTION
Fixes #76.

`_get_default_token` (`odbc2deltalake/destination/azure_utils.py`) cached a single `DefaultAzureCredential` in a process-wide global dict keyed only on the literal string `"cred"` - a single cache slot. Whichever `kwargs` (`managed_identity_client_id`, `workload_identity_tenant_id`, etc.) happen to arrive on the **first** call determine the credential used for **every subsequent call**, regardless of what kwargs later calls actually pass.

`convert_options()` (same file) extracts these identity kwargs from each `AzureDestination`'s `storage_options` specifically so different destinations *can* authenticate with different identities. But because of the shared cache, a pipeline reading from one storage account (identity A) and writing to another with a different `managed_identity_client_id` (identity B) silently authenticates the second destination with the first destination's identity.

Fix: key the cache by the actual kwargs (`tuple(sorted(kwargs.items()))`), so repeated calls with identical kwargs still benefit from caching, but different kwargs correctly get different, independently-cached credentials.

Test: `tests/test_23_azure_token_cache.py` patches `azure.identity.DefaultAzureCredential` with a fake that records its constructor kwargs, and confirms two different `managed_identity_client_id` values now get two distinct tokens (previously silently shared one). Confirmed this test fails against the pre-fix code and passes after.

This PR (and issue #76) were produced by Claude (Anthropic), working on behalf of @dominikpeter - please review accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)