### PR TITLE
Fix postgres identity columns never being detected (case mismatch)

### DIFF
--- a/odbc2deltalake/metadata.py
+++ b/odbc2deltalake/metadata.py
@@ -91,7 +91,7 @@ def _get_table_cols(
             numeric_scale,
             datetime_precision,
             null as generated_always_type_desc,
-            ccu.is_identity=='yes' as is_identity FROM {quoted_db}INFORMATION_SCHEMA.COLUMNS ccu
+            ccu.is_identity=='YES' as is_identity FROM {quoted_db}INFORMATION_SCHEMA.COLUMNS ccu
             """,
             dialect=dialect,
         )

--- a/tests/test_24_postgres_is_identity.py
+++ b/tests/test_24_postgres_is_identity.py
@@ -1,0 +1,57 @@
+"""_get_table_cols' non-tsql (postgres) column query compared
+`ccu.is_identity` against lowercase 'yes'. Postgres's real
+information_schema.columns.is_identity - like every other yes/no column in
+information_schema (is_nullable, is_updatable, etc.) - uses uppercase
+'YES'/'NO' per the SQL standard, confirmed directly against a live postgres
+container:
+
+    select is_identity from information_schema.columns
+    where table_name='<a table with a GENERATED ALWAYS AS IDENTITY column>'
+    -> 'YES'
+
+So `is_identity=='yes'` never matched, and every postgres column - including
+genuine identity columns - was always reported as is_identity=False. The
+only consumer (db_to_delta.py's do_delta_load/exec_write_db_to_delta) uses
+this to auto-select an identity primary key as the delta column for
+append_inserts mode when no delta_col is configured; that auto-detection
+silently never fired for postgres.
+"""
+from typing import TYPE_CHECKING
+import pytest
+
+if TYPE_CHECKING:
+    from tests.conftest import DB_Connection
+
+
+@pytest.mark.order(24)
+def test_postgres_identity_column_detected(connection: "DB_Connection"):
+    if connection.source_server != "postgres":
+        pytest.skip("is_identity casing bug is specific to the postgres query")
+
+    from odbc2deltalake.metadata import _get_table_cols
+    from odbc2deltalake.reader.adbc_reader import ADBCReader
+    import adbc_driver_postgresql.dbapi as adbc_pg
+
+    connstr = connection.conn_str["local"]
+    conn = adbc_pg.connect(connstr, autocommit=True)
+    try:
+        with conn.cursor() as c:
+            c.execute("drop table if exists dbo.identity_probe")
+            c.execute(
+                "create table dbo.identity_probe ("
+                "id integer generated always as identity primary key, "
+                "name text)"
+            )
+
+        reader = ADBCReader(conn, local_db=":memory:", source_dialect="postgres")
+        cols = _get_table_cols(reader, ("dbo", "identity_probe"), dialect="postgres")
+
+        by_name = {c.column_name: c for c in cols}
+        assert by_name["id"].is_identity is True, (
+            "genuine postgres identity column must be reported as is_identity=True"
+        )
+        assert by_name["name"].is_identity is False
+    finally:
+        with conn.cursor() as c:
+            c.execute("drop table if exists dbo.identity_probe")
+        conn.close()


### PR DESCRIPTION
Fixes #77.

`_get_table_cols`'s postgres/non-tsql column query (`odbc2deltalake/metadata.py`) compared `ccu.is_identity` against lowercase `'yes'`. Postgres's real `information_schema.columns.is_identity` - like every other yes/no column in `information_schema` (`is_nullable`, `is_updatable`, etc.) - uses uppercase `'YES'`/`'NO'` per the SQL standard. Confirmed directly against a live postgres container:

```sql
create table t (id integer generated always as identity primary key);
select is_identity from information_schema.columns where table_name='t' and column_name='id';
-- 'YES'
```

Since the comparison is against lowercase `'yes'`, it never matches - every postgres column, including genuine identity columns, is always reported as `is_identity=False`.

The only consumer, `db_to_delta.py`'s `exec_write_db_to_delta`, uses `is_identity` to auto-select a single identity primary key as the delta column for `append_inserts` mode when no `delta_col` is configured. This auto-detection silently never fires for postgres - `append_inserts` mode on an identity-PK postgres table without an explicit `delta_col` fails with `AssertionError: Must provide delta column for append_inserts load` instead of auto-detecting it, as it does correctly for MS SQL Server (whose query path reads `is_identity` from `sys.columns`, a real bit column, not a string comparison, and is unaffected).

Fix: `'yes'` -> `'YES'`.

Test: `tests/test_24_postgres_is_identity.py` creates a real `generated always as identity` column against the live postgres test container and asserts it's correctly detected. Confirmed this test fails against the pre-fix code (`is_identity=False` for a genuine identity column) and passes after.

This PR (and issue #77) were produced by Claude (Anthropic), working on behalf of @dominikpeter - please review accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)