### PR TITLE
Fix data loss: stale writes silently corrupt latest_pk_version after a mid-delta-load full-load fallback

### DIFF
--- a/odbc2deltalake/db_to_delta.py
+++ b/odbc2deltalake/db_to_delta.py
@@ -614,6 +614,16 @@ def do_delta_load(
             infos=infos,
             old_pk_version=old_pk_version,
         )
+        if isinstance(new_delta_load_value, FullLoadResult):
+            # _handle_additional_updates fell back to a full load (eg the
+            # "additional updates" detection failed and restore_last_pk
+            # also failed). do_full_load already correctly rewrote
+            # latest_pk_version from a fresh read of the source - the
+            # do_deletes/write_latest_pk steps below operate on
+            # delta_1/delta_2/primary_keys_ts computed *before* that
+            # fallback, so running them now would overwrite the correct,
+            # freshly-rebuilt state with one built from stale data.
+            return new_delta_load_value
         delta_load_value = new_delta_load_value or delta_load_value
         reader.local_register_update_view(delta_path, _temp_table(infos.table_or_query))
 
@@ -1061,8 +1071,7 @@ def _handle_additional_updates(
             restore_success = False
         if not restore_success:
             logger.warning("No primary keys found, do a full load")
-            do_full_load(infos=infos, mode="append")
-            return
+            return do_full_load(infos=infos, mode="append")
         else:
             _local_view_for_updates()
     sql_query = ex.except_(

--- a/tests/test_25_stale_write_after_full_load_fallback.py
+++ b/tests/test_25_stale_write_after_full_load_fallback.py
@@ -1,0 +1,96 @@
+"""_handle_additional_updates (db_to_delta.py) can fall back to a full load
+mid-delta-load, when the "additional updates" view can't be built and
+restore_last_pk also fails:
+
+    if not restore_success:
+        logger.warning("No primary keys found, do a full load")
+        do_full_load(infos=infos, mode="append")
+        return
+
+That `return` only exits _handle_additional_updates - not do_delta_load.
+do_full_load already correctly (re)writes delta_load/latest_pk_version
+from the fresh full-load snapshot. But do_delta_load's caller keeps going
+right after _handle_additional_updates returns:
+
+    new_delta_load_value = _handle_additional_updates(infos=infos, old_pk_version=old_pk_version)
+    ...
+    do_deletes(..., old_pk_version=old_pk_version, ...)
+    ...
+    write_latest_pk(...)   # mode="overwrite" - overwrites latest_pk_version again
+
+do_deletes and write_latest_pk both operate on delta_1/delta_2/
+primary_keys_ts, all computed BEFORE the full-load fallback happened (ie.
+against pre-restore, stale data), and old_pk_version, which points at the
+LATEST_PK_VERSION *before this whole do_delta_load call started* - not the
+one do_full_load just correctly wrote. write_latest_pk then overwrites
+the correct, freshly-written latest_pk_version with one built from that
+stale data.
+
+This test forces that exact path (mocking the "additional_updates" view
+creation to fail, and restore_last_pk to fail) against a real postgres
+table, and checks whether the final latest_pk_version reflects reality -
+via write_db_to_delta_with_check's built-in check_latest_pk /
+check_latest_pk_pandas ground-truth comparisons.
+"""
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+import pytest
+from .utils import write_db_to_delta_with_check, config_names, get_test_run_configs
+
+if TYPE_CHECKING:
+    from tests.conftest import DB_Connection
+    from pyspark.sql import SparkSession
+
+
+@pytest.mark.order(25)
+@pytest.mark.parametrize("conf_name", config_names)
+def test_stale_write_after_full_load_fallback(
+    connection: "DB_Connection", spark_session: "SparkSession", conf_name: str
+):
+    reader, dest = get_test_run_configs(
+        connection, spark_session, "dbo/company3_stale_fallback"
+    )[conf_name]
+
+    # establish a steady state: full load, then one normal successful delta load
+    write_db_to_delta_with_check(reader, ("dbo", "company3"), dest)
+    with connection.new_connection(conf_name) as nc:
+        with nc.cursor() as cursor:
+            cursor.execute(
+                "insert into dbo.company3(id, name) values "
+                "('c_stale1', 'stale fallback test 1')"
+            )
+    write_db_to_delta_with_check(reader, ("dbo", "company3"), dest)
+
+    # give the next delta load something real to do
+    with connection.new_connection(conf_name) as nc:
+        with nc.cursor() as cursor:
+            cursor.execute(
+                "insert into dbo.company3(id, name) values "
+                "('c_stale2', 'stale fallback test 2')"
+            )
+
+    real_register_view = reader.local_register_view
+
+    def _fail_additional_updates(sql, view_name, *a, **kw):
+        if view_name == "additional_updates":
+            # simulate a concurrent write landing on the source exactly while
+            # the "additional updates" detection is failing/being restored -
+            # the pre-failure delta_1/primary_keys_ts snapshot was already
+            # computed and does NOT include this row; only a fresh read
+            # (what the full-load fallback does) will see it.
+            with connection.new_connection(conf_name) as nc2:
+                with nc2.cursor() as cursor2:
+                    cursor2.execute(
+                        "insert into dbo.company3(id, name) values "
+                        "('c_stale3', 'concurrent during fallback')"
+                    )
+            raise RuntimeError("simulated: cannot build additional_updates view")
+        return real_register_view(sql, view_name, *a, **kw)
+
+    with patch.object(
+        reader, "local_register_view", side_effect=_fail_additional_updates
+    ), patch(
+        "odbc2deltalake.write_utils.restore_pk.restore_last_pk", return_value=False
+    ):
+        # must not corrupt state even though it takes the full-load-fallback path
+        write_db_to_delta_with_check(reader, ("dbo", "company3"), dest)


### PR DESCRIPTION
Fixes #78.

`_handle_additional_updates` (`db_to_delta.py`) - the "strange update"/restore-from-backup handling described in the README - falls back to a full load when the "additional updates" view can't be built and `restore_last_pk` also fails:

```python
if not restore_success:
    logger.warning("No primary keys found, do a full load")
    do_full_load(infos=infos, mode="append")
    return
```

That bare `return` only exits `_handle_additional_updates` - not its caller, `do_delta_load`. `do_full_load()` already correctly (re)writes `delta_load/latest_pk_version` from a fresh read of the source. But `do_delta_load` kept going right after `_handle_additional_updates` returned:

```python
new_delta_load_value = _handle_additional_updates(infos=infos, old_pk_version=old_pk_version)
delta_load_value = new_delta_load_value or delta_load_value
...
do_deletes(..., old_pk_version=old_pk_version, ...)
...
write_latest_pk(...)  # mode="overwrite"
```

`do_deletes` and `write_latest_pk` both operate on `delta_1`/`delta_2`/`primary_keys_ts`, all computed **before** the full-load fallback ran (against pre-restore data), and `old_pk_version` points at the `latest_pk_version` from before this whole `do_delta_load` call started - not the one `do_full_load` just correctly rewrote. `write_latest_pk`'s overwrite then clobbers the correct, freshly-rebuilt `latest_pk_version` with one built from stale data.

## Impact

Concrete, confirmed data loss. Reproduced against a real postgres table: with a row inserted into the source at the exact moment the fallback fires (a genuine race - the pre-fallback `delta_1`/`primary_keys_ts` snapshot doesn't include it, but `do_full_load`'s fresh read does), the row ends up present in the `delta` table but **missing from `latest_pk_version`** afterward:

```
{'id': 'c_stale3', 'xmin': 2310, "'added in persisted data'": 'missing in persisted data'}
InconsistentPrimaryKeyError: Primary keys are not consistent
```

A missing row in `latest_pk_version` means future delta loads will treat that primary key as never-before-seen, potentially causing further downstream inconsistency in the SCD2 history.

## Fix

`_handle_additional_updates` now returns `do_full_load`'s result (a `FullLoadResult`) instead of discarding it. `do_delta_load` checks for a `FullLoadResult` return and returns immediately, skipping the stale `do_deletes`/`write_latest_pk` calls - mirroring the pattern already correctly used by the earlier, similar missing-`latest_pk_version` guard in the same function.

## Test

`tests/test_25_stale_write_after_full_load_fallback.py` reproduces the exact race against a real postgres table (mocking the `additional_updates` view build to fail and `restore_last_pk` to fail, with a genuine concurrent insert at the failure point), then relies on the existing `check_latest_pk`/`check_latest_pk_pandas` ground-truth consistency checks (already run by every test via `write_db_to_delta_with_check`) to catch the corruption. Confirmed this test fails against the pre-fix code (`InconsistentPrimaryKeyError`, missing row) and passes after.

This PR (and issue #78) were produced by Claude (Anthropic), working on behalf of @dominikpeter - please review accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)